### PR TITLE
sapp-linux: implemented window_resizable flag #193 (#205)

### DIFF
--- a/native/sapp-linux/src/lib.rs
+++ b/native/sapp-linux/src/lib.rs
@@ -249,6 +249,7 @@ pub struct sapp_desc {
         Option<unsafe extern "C" fn(_: *const libc::c_char, _: *mut libc::c_void) -> ()>,
     pub width: libc::c_int,
     pub height: libc::c_int,
+    pub window_resizable: bool,
     pub sample_count: libc::c_int,
     pub swap_interval: libc::c_int,
     pub high_dpi: bool,
@@ -474,6 +475,13 @@ pub unsafe extern "C" fn _sapp_x11_create_window(mut visual: *mut Visual, mut de
     );
     let mut hints = XAllocSizeHints();
     (*hints).flags |= PWinGravity;
+    if _sapp.desc.window_resizable == false {
+        (*hints).flags |= PMinSize | PMaxSize;
+        (*hints).min_width = _sapp.desc.width;
+        (*hints).min_height = _sapp.desc.height;
+        (*hints).max_width = _sapp.desc.width;
+        (*hints).max_height = _sapp.desc.height;
+    }
     (*hints).win_gravity = StaticGravity;
     XSetWMNormalHints(_sapp_x11_display, _sapp_x11_window, hints);
     XFree(hints as *mut libc::c_void);
@@ -2983,6 +2991,7 @@ pub static mut _sapp: _sapp_state = _sapp_state {
         fail_userdata_cb: None,
         width: 0,
         height: 0,
+        window_resizable: false,
         sample_count: 0,
         swap_interval: 0,
         high_dpi: false,

--- a/native/sapp-linux/src/x.rs
+++ b/native/sapp-linux/src/x.rs
@@ -27,7 +27,7 @@ pub use Xresource_h::{
     XrmDatabase, XrmDestroyDatabase, XrmGetResource, XrmGetStringDatabase, XrmValue,
 };
 pub use Xutil_h::{
-    IconicState, NormalState, PWinGravity, WithdrawnState, XAllocSizeHints, XClassHint,
+    IconicState, NormalState, PMinSize, PMaxSize, PWinGravity, WithdrawnState, XAllocSizeHints, XClassHint,
     XComposeStatus, XLookupString, XSetWMNormalHints, XSizeHints, XVisualInfo, XWMHints,
     Xutf8SetWMProperties,
 };
@@ -896,6 +896,8 @@ pub mod Xutil_h {
         pub colormap_size: libc::c_int,
         pub bits_per_rgb: libc::c_int,
     }
+    pub const PMinSize: libc::c_long = (1 as libc::c_long) << 4 as libc::c_int;
+    pub const PMaxSize: libc::c_long = (1 as libc::c_long) << 5 as libc::c_int;
     pub const PWinGravity: libc::c_long = (1 as libc::c_long) << 9 as libc::c_int;
     pub const IconicState: libc::c_int = 3 as libc::c_int;
     pub const WithdrawnState: libc::c_int = 0 as libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,6 @@ where
     desc.window_title = title.as_ptr();
 
     #[cfg(not(any(
-        target_os = "linux",
         target_os = "macos",
         target_os = "ios",
         target_os = "android",


### PR DESCRIPTION
native/sapp-linux: implemented window_resizable flag